### PR TITLE
Remove two incorrect apostrophes

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -222,7 +222,7 @@ process.stdin.pipe(stream(processor)).pipe(process.stdout)</code></pre>
       </figure>
 
       <p>
-        Read more about vfile in it’s
+        Read more about vfile in its
         <a href="https://github.com/vfile/vfile">readme</a>.
       </p>
     </article>
@@ -327,7 +327,7 @@ process.stdin.pipe(stream(processor)).pipe(process.stdout)</code></pre>
         every node knows where it originates from.
       </p>
 
-      <p>Read more about unist in it’s <a href="https://github.com/syntax-tree/unist">readme</a>.</p>
+      <p>Read more about unist in its <a href="https://github.com/syntax-tree/unist">readme</a>.</p>
     </article>
 
     <article class="content">


### PR DESCRIPTION
Hello! First off, thanks for all your work on this project. I'm starting to use some unist stuff in a parsing project and it's been helpful.

I was perusing the main landing page, and happened upon two tiny typos ("it's" vs "its"). This PR fixes those typos!