### PR TITLE
Add `remark-slug` package to using unified guide

### DIFF
--- a/doc/learn/using-unified.md
+++ b/doc/learn/using-unified.md
@@ -133,7 +133,7 @@ We can use [`remark-slug`][slug] and [`remark-toc`][toc] for the former, and
 [`rehype-document`][document] to do the latter tasks.
 
 ```sh
-$ npm install remark-toc rehype-document
+$ npm install remark-slug remark-toc rehype-document
 /Users/tilde/example
 ├── remark-slug@5.1.2
 ├── remark-toc@6.0.0


### PR DESCRIPTION
Otherwise the module isn't found

<!--
Read the [contributing guidelines](https://github.com/unifiedjs/.github/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/unifiedjs/.github/blob/master/support.md
https://github.com/unifiedjs/.github/blob/master/contributing.md
-->
