### PR TITLE
Fix broken sample code on create-a-plugin page

### DIFF
--- a/doc/learn/create-a-plugin.md
+++ b/doc/learn/create-a-plugin.md
@@ -235,9 +235,9 @@ function attacher() {
 
       children.forEach(function(child, index) {
         if (
-          is('SentenceNode', children[index - 1]) &&
-          is('WhiteSpaceNode', child) &&
-          is('SentenceNode', children[index + 1])
+          is(children[index - 1], 'SentenceNode') &&
+          is(child, 'WhiteSpaceNode') &&
+          is(children[index + 1], 'SentenceNode')
         ) {
 -          console.log(child)
 +          if (child.value.length !== 1) {


### PR DESCRIPTION
Reversed order of arguments to `is()`. Code in earlier codeblock works, but last codeblock is different and doesn't work.