### PR TITLE
Fixed retext-english usage

### DIFF
--- a/doc/learn/create-an-editor.md
+++ b/doc/learn/create-an-editor.md
@@ -269,7 +269,7 @@ Change `index.js` like so:
  import diff from 'virtual-dom/diff.js'
  import patch from 'virtual-dom/patch.js'
 +import {unified} from 'unified'
-+import retextEnglish from 'retext-english'
++import retextEnglish, {Parser} from 'retext-english'
 
 +const processor = unified().use(retextEnglish)
  const root = document.querySelector('#root')
@@ -281,7 +281,7 @@ Change `index.js` like so:
 
 -  function parse() {}
 +  function parse(value) {
-+    return processor.runSync(processor.parse(value))
++    return processor.runSync(new Parser().parse(value))
 +  }
 
    function highlight() {}
@@ -304,7 +304,7 @@ it:
 --- a/index.js
 +++ b/index.js
 @@ -32,5 +32,19 @@ function render(text) {
-     return processor.runSync(processor.parse(value))
+     return processor.runSync(new Parser().parse(value))
    }
 
 -  function highlight() {}


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [ ] If applicable, I’ve added docs and tests

### Description of changes

retext-english now provides a Parser object. The previous code will not run with the current version of retest-english, which will trigger the warning `TypeError: Cannot call a class constructor without |new|` in runtime.

The solution is import the `Parser` object from the package and use it instead when generating the syntax tree.

<!--do not edit: pr-->
